### PR TITLE
fix compatibility with distzilla 5

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -39,3 +39,8 @@ repository.url  = https://github.com/stephenenelson/video-xine
 repository.type = git
 
 [PkgVersion]
+
+[Encoding]
+encoding = bytes
+filename = t/test.ogg
+filename = t/video_xine_test.mp4


### PR DESCRIPTION
Dist::Zilla 5 considers all files to be UTF-8 by default. Files with different encodings must be set in dist.ini.
